### PR TITLE
update: player-initial-state-to-use-single-bullet&bugs

### DIFF
--- a/src/gdd/Global.java
+++ b/src/gdd/Global.java
@@ -45,4 +45,9 @@ public class Global {
     // Speed PowerUp constants
     public static final int SPEED_BOOST_AMOUNT = 2; // Speed increase amount
     public static final int MAX_PLAYER_SPEED = 14; // Maximum speed cap (8 default + 3 boosts)
+    
+    // NEW: Shooting mode constants
+    public static final int SINGLE_SHOT_LIMIT = 1; // Default shot limit before SpeedUp collection
+    public static final int NORMAL_SHOT_LIMIT = 6; // Normal shot limit after SpeedUp collection
+    public static final int MULTISHOT_SHOT_LIMIT = 15; // Enhanced shot limit with multishot active
 }

--- a/src/gdd/powerup/SpeedUp.java
+++ b/src/gdd/powerup/SpeedUp.java
@@ -33,9 +33,14 @@ public class SpeedUp extends PowerUp {
         }
     }
 
+    // UPDATED: Modified to enable multiple shots capability
     public void upgrade(Player player) {
-        // Apply permanent speed boost with cap
+        // Enable multiple shots capability (main feature)
+        player.enableMultipleShots();
+        
+        // Also apply speed boost as secondary benefit
         player.applySpeedBoost(SPEED_BOOST_AMOUNT);
+        
         this.die(); // Remove the power-up after use
     }
 

--- a/src/gdd/scene/Scene1.java
+++ b/src/gdd/scene/Scene1.java
@@ -453,19 +453,29 @@ public class Scene1 extends JPanel {
         int maxShots = player.getMaxShots();
         g.drawString("Shots: " + shots.size() + "/" + maxShots, 150, 40);
         
+        // UPDATED: Show SpeedUp collection status
+        g.setColor(Color.yellow);
+        if (player.hasCollectedSpeedUp()) {
+            g.drawString("✓ Multi-Shot Unlocked", 300, 20);
+        } else {
+            g.setColor(Color.red);
+            g.drawString("✗ Single Shot Only", 300, 20);
+        }
+        
         // Powerup status
+        g.setColor(Color.white);
         if (player.hasMultishot()) {
             int remainingSeconds = player.getMultishotFramesRemaining() / 60;
             g.setColor(Color.yellow);
-            g.drawString("🔥 MULTISHOT: " + remainingSeconds + "s", 300, 20);
+            g.drawString("🔥 MULTISHOT: " + remainingSeconds + "s", 300, 35);
             g.setColor(Color.red);
-            g.drawString("AUTO-FIRE ACTIVE!", 300, 35);
+            g.drawString("AUTO-FIRE ACTIVE!", 300, 50);
         }
         
         // Speed status  
         if (player.getSpeed() > 8) { // Show if speed is above default
             g.setColor(Color.cyan);
-            g.drawString("⚡ SPEED: " + player.getSpeed(), 300, 50);
+            g.drawString("⚡ SPEED: " + player.getSpeed(), 450, 40);
         }
         
         // Phase information
@@ -482,13 +492,13 @@ public class Scene1 extends JPanel {
                 phaseText += " (WAR!)";
                 break;
         }
-        g.drawString(phaseText, 450, 20);
+        g.drawString(phaseText, 550, 20);
         
         // Wave information
         if (waveActive) {
             g.setColor(Color.red);
             int remainingSeconds = (waveEndFrame - frame) / 60;
-            g.drawString("🚨 " + currentWaveType + " WAVE: " + remainingSeconds + "s", 450, 40);
+            g.drawString("🚨 " + currentWaveType + " WAVE: " + remainingSeconds + "s", 550, 40);
         }
         
     }
@@ -643,7 +653,7 @@ public class Scene1 extends JPanel {
         // player
         player.act();
         
-        // Auto-fire when multishot is active (controlled rate)
+        // UPDATED: Auto-fire only works if player has collected SpeedUp
         if (player.canAutoFire() && shots.size() < player.getMaxShots() - 2) {
             int x = player.getX();
             int y = player.getY();
@@ -998,6 +1008,7 @@ public class Scene1 extends JPanel {
                 int x = player.getX();
                 int y = player.getY();
 
+                // UPDATED: Modified shooting logic to respect single-shot limitation
                 if (key == KeyEvent.VK_SPACE) {
                     int maxShots = player.getMaxShots();
                     System.out.println("Shots: " + shots.size() + "/" + maxShots);
@@ -1006,8 +1017,8 @@ public class Scene1 extends JPanel {
                         Shot shot = new Shot(x, y);
                         shots.add(shot);
                         
-                        // Create additional shots if player has multishot active
-                        if (player.hasMultishot()) {
+                        // Only create additional shots if player can shoot multiple AND has multishot
+                        if (player.canShootMultiple() && player.hasMultishot()) {
                             int extraShots = player.getExtraShots();
                             for (int i = 1; i <= extraShots && shots.size() < maxShots; i++) {
                                 // Create shots with spread pattern

--- a/src/gdd/sprite/Player.java
+++ b/src/gdd/sprite/Player.java
@@ -1,11 +1,11 @@
 package gdd.sprite;
 
 import static gdd.Global.*;
+import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
 import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
 import javax.swing.ImageIcon;
 
 public class Player extends Sprite {
@@ -20,6 +20,9 @@ public class Player extends Sprite {
     private int extraShots = 0;
     private int autoFireCooldown = 0;
     private int invincibilityFrames = 0;
+    
+    // NEW: Track if player has collected SpeedUp powerup
+    private boolean hasCollectedSpeedUp = false;
     
 
     private Rectangle bounds = new Rectangle(175,135,17,32);
@@ -179,13 +182,19 @@ public class Player extends Sprite {
         return multishotFramesRemaining;
     }
     
+    // UPDATED: Modified to respect single-shot limitation
     public int getMaxShots() {
-        // Base limit is 6, but increase to 15 when multishot is active
+        // Only allow 1 shot until SpeedUp is collected
+        if (!hasCollectedSpeedUp) {
+            return 1;
+        }
+        // After collecting SpeedUp, allow normal shot limits
         return hasMultishot() ? 15 : 6;
     }
     
+    // UPDATED: Auto-fire only works if player has collected SpeedUp
     public boolean canAutoFire() {
-        return hasMultishot() && autoFireCooldown <= 0;
+        return hasCollectedSpeedUp && hasMultishot() && autoFireCooldown <= 0;
     }
     
     public void triggerAutoFire() {
@@ -210,6 +219,19 @@ public class Player extends Sprite {
     
     public boolean canReceiveSpeedBoost() {
         return currentSpeed < MAX_PLAYER_SPEED; // Can get speed until hitting cap
+    }
+    
+    // NEW: Methods to handle SpeedUp powerup collection
+    public void enableMultipleShots() {
+        this.hasCollectedSpeedUp = true;
+    }
+    
+    public boolean canShootMultiple() {
+        return hasCollectedSpeedUp;
+    }
+    
+    public boolean hasCollectedSpeedUp() {
+        return hasCollectedSpeedUp;
     }
     
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dashboard indicator showing whether multi-shot is unlocked via SpeedUp powerup.
  * Introduced shot limits based on player state: single shot before SpeedUp, increased limits after collecting SpeedUp, and higher limits with multishot active.

* **Improvements**
  * Auto-fire and multi-shot capabilities are now only available after collecting the SpeedUp powerup.
  * Dashboard layout adjusted for improved clarity and readability.

* **Bug Fixes**
  * Prevented multishot and auto-fire from being used before SpeedUp is collected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->