### PR TITLE
fix: timer delay in scene1 and scene2

### DIFF
--- a/src/gdd/scene/Scene1.java
+++ b/src/gdd/scene/Scene1.java
@@ -37,6 +37,7 @@ import java.util.Random;
 import javax.swing.ImageIcon;
 import javax.swing.JPanel;
 import javax.swing.Timer;
+
 public class Scene1 extends JPanel {
 
     private int frame = 0;
@@ -68,7 +69,7 @@ public class Scene1 extends JPanel {
     private List<Star> stars = new ArrayList<>();
 
     private boolean gameOverSoundPlayed = false; // Flag to prevent multiple game over sounds
-
+    private long gameStartTime;
     // Star class for random background stars
     private static class Star {
         int x, y, size, speed;
@@ -114,6 +115,7 @@ public class Scene1 extends JPanel {
     }
     
     public void start() {
+        gameStartTime = System.currentTimeMillis();
         addKeyListener(new TAdapter());
         setFocusable(true);
         requestFocusInWindow();
@@ -553,11 +555,13 @@ public class Scene1 extends JPanel {
     private void update() {
 
         // Update game timer
-        framesSinceLastSecond++;
-        if (framesSinceLastSecond >= 60) { // 60 FPS
-            gameTimeSeconds++;
-            framesSinceLastSecond = 0;
-        }
+        // framesSinceLastSecond++;
+        // if (framesSinceLastSecond >= 60) { // 60 FPS
+        //     gameTimeSeconds++;
+        //     framesSinceLastSecond = 0;
+        // }
+        long elapsedMs = System.currentTimeMillis() - gameStartTime;
+        gameTimeSeconds = (int) (elapsedMs / 1000);
         
         // Update phase-based enemy behavior
         updateEnemyPhase();

--- a/src/gdd/scene/Scene2.java
+++ b/src/gdd/scene/Scene2.java
@@ -74,7 +74,7 @@ public class Scene2 extends JPanel {
     private boolean bossIntroPlayed = false; // Track if boss intro has been played
 
     private boolean gameOverSoundPlayed = false; // Track if game over sound has been played
-
+    private long gameStartTime;
     // Star class for random background stars
     private static class Star {
         int x, y, size, speed;
@@ -131,6 +131,7 @@ public class Scene2 extends JPanel {
     
     public void start() {
         // Indicate to Alien1 that this is level 2
+        gameStartTime = System.currentTimeMillis();
         gdd.sprite.Alien1.IS_LEVEL2 = true;
 
         addKeyListener(new TAdapter());
@@ -727,12 +728,15 @@ public class Scene2 extends JPanel {
         }
         
         // Update game timer
-        framesSinceLastSecond++;
-        if (framesSinceLastSecond >= 60) {
-            gameTimeSeconds++;
-            framesSinceLastSecond = 0;
-        }
+        // framesSinceLastSecond++;
+        // if (framesSinceLastSecond >= 60) {
+        //     gameTimeSeconds++;
+        //     framesSinceLastSecond = 0;
+        // }
         
+        long elapsedMs = System.currentTimeMillis() - gameStartTime;
+        gameTimeSeconds = (int) (elapsedMs / 1000);
+
         updateEnemyPhase();
         updateStarField();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved game timer accuracy by switching from frame-based timing to real-time tracking in both scenes. The timer now reflects actual elapsed time rather than relying on frame counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->